### PR TITLE
0.40.1 - Bugfix EmployeeDutyStatistic.aspx

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "NIU++",
   "author": "Gerald Baeck",
   "description": "Chrome Erweiterung zur einfacheren Bedienung des internen Verwaltungssystems des Wiener Roten Kreuz (NIU).",
-  "version": "0.40",
+  "version": "0.40.1",
 
   "homepage_url": "http://baeck.at",
   "options_ui" : {

--- a/src/content_scripts/EmployeeDutyStatistic.js
+++ b/src/content_scripts/EmployeeDutyStatistic.js
@@ -78,7 +78,8 @@ $(document).ready(function() {
             switch (i) {
               case 4: // Fahrer
               case 5: // SAN1
-              case 6: // SAN2
+              case 6: // SAN2, Error Try-Catch um bei 2-spaltigen Dienstarten keinen Programmabbruch zu verursachen.
+                try {
                 if (!$(val).text().includes(dienstnummer) && $(val).text() !== '') {
                   var kollege = $(val).text().substring(0, $(val).text().indexOf('(')).trim();
                   rawKollegen.push(kollege);
@@ -98,6 +99,10 @@ $(document).ready(function() {
                   }
                 }
                 break;
+                }
+                catch(err) {
+                break;
+                }
               default:
                 break;
             }
@@ -105,7 +110,8 @@ $(document).ready(function() {
             switch (i) {
               case 5: // Fahrer
               case 6: // SAN1
-              case 7: // SAN2
+              case 7: // SAN2, Error Try-Catch um bei 2-spaltigen Dienstarten keinen Programmabbruch zu verursachen.
+                try {
                 if (!$(val).text().includes(dienstnummer) && $(val).text() !== '') {
                   var kollege = $(val).text().substring(0, $(val).text().indexOf('(')).trim();
                   rawKollegen.push(kollege);
@@ -125,6 +131,10 @@ $(document).ready(function() {
                   }
                 }
                 break;
+                }
+                catch (err) {
+                  break;
+                }
               default:
                 break;
             }


### PR DESCRIPTION
2-spaltige Dienstpläne bringen die Statistik zum Absturz.
Error Try-Catch als Übergangslösung für die problematische Spalte eingebaut.