### PR TITLE
Resolved styling issues with week-day selector

### DIFF
--- a/src/content_scripts/DutyRoster.js
+++ b/src/content_scripts/DutyRoster.js
@@ -211,13 +211,22 @@ $(document).ready(function() {
       });
     }
 
-  var hideDays = [];
-	$("[id^='label_nlh_day_filter']").css("font-weight", "normal");
+    var hideDays = [];
 
-    $("[name='nlh_day_filter[]']").not(":checked").each(function(){
-    	var val = $(this).val();
-    	hideDays.push(val);
-    	$("#label_nlh_day_filter_" + val).css("font-weight", "bold");
+    $("[name='nlh_day_filter[]']").each(function(){
+      var $this = $(this);
+      var val = $this.val();
+      var $label = $("#label_nlh_day_filter_" + val);
+
+      if (!$this.prop("checked"))
+      {
+          hideDays.push(val);
+          $label.css("font-weight", "normal");
+      }
+      else
+      {
+        $label.css("font-weight", "bold");
+      }
     });
 
     if (hideDays && hideDays.length) {
@@ -226,8 +235,6 @@ $(document).ready(function() {
         var hideDayShort = hideDays[i];
         $("[data-day='"+hideDayShort+"']").hide();
       }
-    } else {
-      $("[data-day]").show();
     }
 
     if ($('#DutyRosterFilterNKTW').is(':checked')) {
@@ -405,6 +412,7 @@ $(document).ready(function() {
 		    .attr("id", "label_" + id)
 		    .html(day.name)
 		    .css("vertical-align", "top")
+		    .css("font-weight", "bold")
 		    .appendTo($FilterItem);
 
 	    $FilterDay.append($FilterItem);


### PR DESCRIPTION
week day filter labels are now **bold** per default. Also, when a filter is unchecked, its label goes back to normal and when it's checked back again, the label becomes bold again