### PR TITLE
fix ical for DutyRoster

### DIFF
--- a/js/ouical/ouical.js
+++ b/js/ouical/ouical.js
@@ -74,7 +74,7 @@
           'BEGIN:VCALENDAR',
           'VERSION:2.0',
           'BEGIN:VEVENT',
-          'URL:' + document.URL,
+          'URL:' + encodeURIComponent(document.URL),
           'DTSTART:' + (startTime || ''),
           'DTEND:' + (endTime || ''),
           'SUMMARY:' + (event.title || ''),


### PR DESCRIPTION
Servus,

ich hatte manchmal das Problem dass die Exports für ical nicht funktionieren.
Hier einmal **nicht funktionierend** über **Geplante Dienste** und einmal **funktionierend** über **Today**:

**nicht funktionierend**
```
BEGIN:VCALENDAR
VERSION:2.0
BEGIN:VEVENT
URL:https://niu.wrk.at/Kripo/DutyRosterNH/DutyRoster.aspx?DutyStage=planned
```

**funktionierend**
```
BEGIN:VCALENDAR
VERSION:2.0
BEGIN:VEVENT
URL:https://niu.wrk.at/Kripo/Today/Today.aspx
DTSTART:XXX
DTEND:XXX
SUMMARY:KTW
DESCRIPTION:Fahrer: XXX
Sanitäter1: XXX
Sanitäter2: XXX
```
Stellt sich heraus dass beim generieren im **DutyRoster.aspx** ein `#` am Ende der URL angehängt wird und es dadurch nicht mehr funktioniert. Mein fix korrigiert dies mit `encodeURIComponent()` .

Erfolgreich getestet unter Google Chrome Version 88.0.4324.96 (Official Build) (x86_64) running on macOS 11.1 Big Sur.